### PR TITLE
Transpile globals to an AMD format

### DIFF
--- a/lib/global_amd.js
+++ b/lib/global_amd.js
@@ -1,5 +1,5 @@
 var esprima = require("esprima");
-var jsStringEscape = require('js-string-escape');
+var jsStringEscape = require("js-string-escape");
 
 module.exports = function(load){
 	var name = load.name;
@@ -8,13 +8,20 @@ module.exports = function(load){
 	var metaDeps = metadata.deps || [];
 	var deps = ["module", "@loader"].concat(metaDeps);
 
+	var source = jsStringEscape(load.source);
 	var code = "define(\"" + name + "\", " + JSON.stringify(deps) +
-		", function(__module, __loader) {\n" +
-		"  __loader.get(\"@@global-helpers\").prepareGlobal(__module.id, []);\n" +
-		"  (function() {\n" +
-		"    " + load.source +
-		"\n  }).call(__loader.global);" +
-		"\n  return __loader.get(\"@@global-helpers\").retrieveGlobal(__module.id, false);" +
+		", function(module, loader) {\n" +
+		"  loader.get(\"@@global-helpers\").prepareGlobal(module.id, []);\n" +
+		"  var define = loader.global.define;\n" +
+        "  var require = loader.global.require;\n" +
+		"  var source = \"" + source + "\";\n" +
+        "  loader.global.define = undefined;\n" +
+        "  loader.global.module = undefined;\n" +
+        "  loader.global.exports = undefined;\n" +
+        "  loader.__exec({'source': source, 'address': module.uri});\n" +
+        "  loader.global.require = require;\n" +
+        "  loader.global.define = define;\n" +
+		"\n  return loader.get(\"@@global-helpers\").retrieveGlobal(module.id, false);" +
 		"\n});";
 
 	var ast = esprima.parse(code);

--- a/lib/global_amd.js
+++ b/lib/global_amd.js
@@ -5,16 +5,16 @@ module.exports = function(load){
 	var name = load.name;
 	var metadata = load.metadata || {};
 
-	var deps = metadata.deps || [];
+	var metaDeps = metadata.deps || [];
+	var deps = ["module", "@loader"].concat(metaDeps);
 
-	var code = "System.register(\"" + name + "\", " + JSON.stringify(deps) +
-		", false, function(__require, " +
-		"__exports, __module) {\n" +
-		"  System.get(\"@@global-helpers\").prepareGlobal(__module.id, []);\n" +
+	var code = "define(\"" + name + "\", " + JSON.stringify(deps) +
+		", function(__module, __loader) {\n" +
+		"  __loader.get(\"@@global-helpers\").prepareGlobal(__module.id, []);\n" +
 		"  (function() {\n" +
 		"    " + load.source +
-		"\n  }).call(System.global);" +
-		"\n  return System.get(\"@@global-helpers\").retrieveGlobal(__module.id, false);" +
+		"\n  }).call(__loader.global);" +
+		"\n  return __loader.get(\"@@global-helpers\").retrieveGlobal(__module.id, false);" +
 		"\n});";
 
 	var ast = esprima.parse(code);

--- a/lib/global_amd.js
+++ b/lib/global_amd.js
@@ -1,16 +1,18 @@
 var esprima = require("esprima");
 var jsStringEscape = require('js-string-escape');
 
-module.exports = function(load) {
-	var options = {};
-	
-	options.address = load.name;
-	
-	if(load.metadata){
-		options.metadata = load.metadata;
-	}
-	
-	var source = "System.define('"+load.name+"','"+jsStringEscape(load.source)+"',"+JSON.stringify(options)+");";
-	var ast = esprima.parse(source);
+module.exports = function(load){
+	var name = load.name;
+
+	var code = "System.register(\"" + name + "\", [], false, function(__require, " +
+		"__exports, __module) {\n" +
+		"  System.get(\"@@global-helpers\").prepareGlobal(__module.id, []);\n" +
+		"  (function() {\n" +
+		"    " + load.source +
+		"\n  }).call(System.global);" +
+		"\n  return System.get(\"@@global-helpers\").retrieveGlobal(__module.id, false);" +
+		"\n});";
+
+	var ast = esprima.parse(code);
 	return ast;
 };

--- a/lib/global_amd.js
+++ b/lib/global_amd.js
@@ -3,8 +3,12 @@ var jsStringEscape = require('js-string-escape');
 
 module.exports = function(load){
 	var name = load.name;
+	var metadata = load.metadata || {};
 
-	var code = "System.register(\"" + name + "\", [], false, function(__require, " +
+	var deps = metadata.deps || [];
+
+	var code = "System.register(\"" + name + "\", " + JSON.stringify(deps) +
+		", false, function(__require, " +
 		"__exports, __module) {\n" +
 		"  System.get(\"@@global-helpers\").prepareGlobal(__module.id, []);\n" +
 		"  (function() {\n" +

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,7 @@ var convert = function(moduleName, converter, result, options, done, load){
 	if(!load) {
 		load = {};
 	}
-	
+
 	fs.readFile(__dirname+"/tests/"+moduleName+".js", function(err, data){
 		if(err) {
 			assert.fail(err, null, "reading "+__dirname+"/tests/"+file+" failed");
@@ -37,7 +37,7 @@ var convert = function(moduleName, converter, result, options, done, load){
 		load = extend({source: ""+data, address: __dirname+"/tests/"+moduleName+".js", name: moduleName}, load);
 		var res = generate(converter(load, options)).code;
 		assert.ok(res, "got back a value");
-		
+
 		fs.readFile(__dirname+"/tests/expected/"+result, function(err, resultData){
 			if(err) {
 				assert.fail(err, null, "reading "+__dirname+"/tests/expected/"+result+" failed");
@@ -59,13 +59,13 @@ var doTranspile = function(moduleName, format, result, resultFormat, options, do
 			assert.fail(err, null, "reading "+__dirname+"/tests/"+file+" failed");
 		}
 		var res = transpile.to({
-			source: ""+data, 
-			address: __dirname+"/tests/"+moduleName+".js", 
-			name: moduleName, 
+			source: ""+data,
+			address: __dirname+"/tests/"+moduleName+".js",
+			name: moduleName,
 			metadata: {format: format}
 		}, resultFormat, options);
 		assert.ok(res, "got back a value");
-		
+
 		fs.readFile(__dirname+"/tests/expected/"+result, function(err, resultData){
 			if(err) {
 				assert.fail(err, null, "reading "+__dirname+"/tests/expected/"+result+" failed");
@@ -97,7 +97,7 @@ describe('es6 - cjs', function(){
 	it('should work', function(done){
 		convert("es6",es62cjs,"es6_cjs.js", done);
 	});
-    
+
 	it('works if global.System is something else (#14)', function(done){
 		global.System = {};
 		convert("es6",es62cjs,"es6_cjs.js", done);
@@ -129,11 +129,11 @@ describe('steal - amd', function(){
     it('should work', function(done){
 		convert("steal",steal2amd,"steal_amd.js", done);
     });
-    
+
     it('should work with namedDefines', function(done){
 		convert("steal",steal2amd,"steal_amd_named_defines.js", {namedDefines: true}, done);
     });
-    
+
     it('should leave nested steals alone', function(done){
 		convert("nested_steal",steal2amd,"nested_steal_amd.js", done);
     });
@@ -146,7 +146,7 @@ describe('global - amd', function(){
 });
 
 describe("transpile", function(){
-	
+
 	it('able to steal to cjs', function(){
 		var res = transpile.able("steal","cjs");
 		assert.deepEqual(res,["steal","amd"]);
@@ -156,7 +156,7 @@ describe("transpile", function(){
 		var res = transpile.able("steal","amd");
 		assert.deepEqual(res,["steal"]);
     });
-    
+
     it('able to es6 to amd', function(){
 		var res = transpile.able("es6","amd");
 		assert.deepEqual(res,["es6"]);
@@ -169,9 +169,9 @@ describe("transpile", function(){
 	it('able to global to amd', function(done){
 		doTranspile("global","global","global_amd_with_format.js","amd", done);
 	});
-	
+
 	it('able to steal to cjs with missing args', function(done){
-		
+
 		doTranspile("steal_no_value_arg","steal","steal_no_value_arg_cjs.js","cjs",done);
 	});
 });
@@ -181,7 +181,7 @@ describe('amd - amd', function(){
 	it('should work', function(done){
 		convert("amd",amd2amd,"amd_amd.js", {namedDefines: true},done);
 	});
-    
+
 	it("works with transpile", function(done){
 		doTranspile("amd","amd","amd_amd.js","amd",{namedDefines: true}, done);
 	});
@@ -195,7 +195,7 @@ describe('amd - amd', function(){
 		};
 		convert("amd_deps",amd2amd,"amd_deps.js", options, done);
 	});
-	
+
 	it("should rename the define name if able", function(done){
 		convert("amd_named",amd2amd,"amd_named_amd.js", {namedDefines: true},done,{
 			name: "redefined"
@@ -239,7 +239,7 @@ describe('cjs - amd', function(){
 		convert("cjs_deps", cjs2amd, "cjs_deps.js", options, done);
 	});
 	it('should be able to add named defines',function(done){
-		
+
 		var options = {
 			normalizeMap: {
 				'./b': 'b'
@@ -277,9 +277,9 @@ describe('normalize options', function(){
 			namedDefines: true
 		}, done);
 	});
-	
+
 	it('es6 - cjs + normalize',function(done){
-		
+
 		convert("es_needing_normalize",es62cjs,"es_needing_normalize_cjs.js", {
 			normalize: function(name){
 
@@ -293,11 +293,11 @@ describe('normalize options', function(){
 				return name;
 			}
 		}, done);
-		
+
 	});
-	
+
 	it('amd - cjs + normalize',function(done){
-		
+
 		convert("amd_needing_normalize",amd2cjs,"amd_needing_normalize_cjs.js", {
 			normalize: function(name){
 
@@ -311,17 +311,17 @@ describe('normalize options', function(){
 				return name;
 			}
 		}, done);
-		
+
 	});
-	
+
 	it('steal - cjs + normalize',function(done){
-		
+
 		doTranspile("steal_needing_normalize","steal","steal_needing_normalize_cjs.js","cjs", {
 			normalize: function(name){
 				return name+"-normalized";
 			}
 		},done);
-		
+
 	});
 
 	it("cjs - cjs + normalize", function(done){
@@ -331,7 +331,7 @@ describe('normalize options', function(){
 			}
 		}, done);
 	});
-	
+
 });
 
 describe("Source Maps", function(){

--- a/test/tests/expected/global_amd.js
+++ b/test/tests/expected/global_amd.js
@@ -1,10 +1,19 @@
 define('global', [
     'module',
     '@loader'
-], function (__module, __loader) {
-    __loader.get('@@global-helpers').prepareGlobal(__module.id, []);
-    (function () {
-        var GLOBAL = 'I don\'t like "Quotes"';
-    }.call(__loader.global));
-    return __loader.get('@@global-helpers').retrieveGlobal(__module.id, false);
+], function (module, loader) {
+    loader.get('@@global-helpers').prepareGlobal(module.id, []);
+    var define = loader.global.define;
+    var require = loader.global.require;
+    var source = 'var GLOBAL = "I don\'t like \\"Quotes\\"";';
+    loader.global.define = undefined;
+    loader.global.module = undefined;
+    loader.global.exports = undefined;
+    loader.__exec({
+        'source': source,
+        'address': module.uri
+    });
+    loader.global.require = require;
+    loader.global.define = define;
+    return loader.get('@@global-helpers').retrieveGlobal(module.id, false);
 });

--- a/test/tests/expected/global_amd.js
+++ b/test/tests/expected/global_amd.js
@@ -1,7 +1,10 @@
-System.register('global', [], false, function (__require, __exports, __module) {
-    System.get('@@global-helpers').prepareGlobal(__module.id, []);
+define('global', [
+    'module',
+    '@loader'
+], function (__module, __loader) {
+    __loader.get('@@global-helpers').prepareGlobal(__module.id, []);
     (function () {
         var GLOBAL = 'I don\'t like "Quotes"';
-    }.call(System.global));
-    return System.get('@@global-helpers').retrieveGlobal(__module.id, false);
+    }.call(__loader.global));
+    return __loader.get('@@global-helpers').retrieveGlobal(__module.id, false);
 });

--- a/test/tests/expected/global_amd.js
+++ b/test/tests/expected/global_amd.js
@@ -1,1 +1,7 @@
-System.define('global', 'var GLOBAL = "I don\'t like \\"Quotes\\"";', { 'address': 'global' });
+System.register('global', [], false, function (__require, __exports, __module) {
+    System.get('@@global-helpers').prepareGlobal(__module.id, []);
+    (function () {
+        var GLOBAL = 'I don\'t like "Quotes"';
+    }.call(System.global));
+    return System.get('@@global-helpers').retrieveGlobal(__module.id, false);
+});

--- a/test/tests/expected/global_amd_with_format.js
+++ b/test/tests/expected/global_amd_with_format.js
@@ -1,10 +1,19 @@
 define('global', [
     'module',
     '@loader'
-], function (__module, __loader) {
-    __loader.get('@@global-helpers').prepareGlobal(__module.id, []);
-    (function () {
-        var GLOBAL = 'I don\'t like "Quotes"';
-    }.call(__loader.global));
-    return __loader.get('@@global-helpers').retrieveGlobal(__module.id, false);
+], function (module, loader) {
+    loader.get('@@global-helpers').prepareGlobal(module.id, []);
+    var define = loader.global.define;
+    var require = loader.global.require;
+    var source = 'var GLOBAL = "I don\'t like \\"Quotes\\"";';
+    loader.global.define = undefined;
+    loader.global.module = undefined;
+    loader.global.exports = undefined;
+    loader.__exec({
+        'source': source,
+        'address': module.uri
+    });
+    loader.global.require = require;
+    loader.global.define = define;
+    return loader.get('@@global-helpers').retrieveGlobal(module.id, false);
 });

--- a/test/tests/expected/global_amd_with_format.js
+++ b/test/tests/expected/global_amd_with_format.js
@@ -1,7 +1,10 @@
-System.register('global', [], false, function (__require, __exports, __module) {
-    System.get('@@global-helpers').prepareGlobal(__module.id, []);
+define('global', [
+    'module',
+    '@loader'
+], function (__module, __loader) {
+    __loader.get('@@global-helpers').prepareGlobal(__module.id, []);
     (function () {
         var GLOBAL = 'I don\'t like "Quotes"';
-    }.call(System.global));
-    return System.get('@@global-helpers').retrieveGlobal(__module.id, false);
+    }.call(__loader.global));
+    return __loader.get('@@global-helpers').retrieveGlobal(__module.id, false);
 });

--- a/test/tests/expected/global_amd_with_format.js
+++ b/test/tests/expected/global_amd_with_format.js
@@ -1,4 +1,7 @@
-System.define('global', 'var GLOBAL = "I don\'t like \\"Quotes\\"";', {
-    'address': 'global',
-    'metadata': { 'format': 'global' }
+System.register('global', [], false, function (__require, __exports, __module) {
+    System.get('@@global-helpers').prepareGlobal(__module.id, []);
+    (function () {
+        var GLOBAL = 'I don\'t like "Quotes"';
+    }.call(System.global));
+    return System.get('@@global-helpers').retrieveGlobal(__module.id, false);
 });


### PR DESCRIPTION
This changes globals to transpile to AMD instead of System.define. The reason is that System.define has a problem that makes it not ideal as a target format for bundling. The reason is that when a `System.define` is called it begins the normalization process immediately, so if another module modifies normalization (such as the [system-npm](https://github.com/stealjs/system-npm) plugin) normalization will be complete before that other module has run its code.

The fix is to do eval inside of an AMD module. Using SystemJS' `@@global-helper` we can retrieve globals set by the eval.